### PR TITLE
mint: simplify `AmountSplit` by iterating over amount bits

### DIFF
--- a/mint/mint.go
+++ b/mint/mint.go
@@ -16,8 +16,8 @@ import (
 	"github.com/samber/lo"
 	log "github.com/sirupsen/logrus"
 	"math"
+	"math/bits"
 	"reflect"
-	"strconv"
 	"strings"
 )
 
@@ -381,25 +381,16 @@ func (m *Mint) checkSpendable(proof cashu.Proof) bool {
 	return !found
 }
 
-// AmountSplit will convert amount into binary and return array with decimal binary values
+// AmountSplit will return an array with all decimal binary values (i.e. powers
+// of two) that the given amount consists of.
 func AmountSplit(amount uint64) []uint64 {
-	bin := reverse(strconv.FormatUint(amount, 2))
 	rv := make([]uint64, 0)
-	for i, b := range []byte(bin) {
-		if b == 49 {
-			rv = append(rv, uint64(math.Pow(2, float64(i))))
+	for i := 0; i < bits.Len64(amount); i++ {
+		if (amount & (1 << i)) != 0 { // if bit i is set, add 2**i to list
+			rv = append(rv, 1 << i)
 		}
 	}
 	return rv
-}
-
-// reverse string. used to reverse binary representation of amount
-func reverse(s string) string {
-	runes := []rune(s)
-	for i, j := 0, len(runes)-1; i < j; i, j = i+1, j-1 {
-		runes[i], runes[j] = runes[j], runes[i]
-	}
-	return string(runes)
 }
 
 // verifySplitAmount will verify amount


### PR DESCRIPTION
Seems unnecessary to involve other data types like strings or floating points here, we can just directly operate on the amount uint64 variable by iterating over all the bits and add `2**i` (expressed as shift operation `1<<i`, to avoid Math.pow) to the return list if bit i is set.