### PR TITLE
mint: log mint server's listening address (ip:port) at start

### DIFF
--- a/cmd/mint/mint.go
+++ b/cmd/mint/mint.go
@@ -13,7 +13,7 @@ import (
 // @contact.url https://8333.space:3338
 func main() {
 	cashuLog.Configure(api.Config.LogLevel)
-	log.Info("starting (feni) cashu mint server")
 	m := api.New()
+	log.Info("starting (feni) cashu mint server, listening on ", m.HttpServer.Addr)
 	m.StartServer()
 }


### PR DESCRIPTION
I think it's helpful to see in the log output at start where the mint server listens on (though the IP will mostly be 0.0.0.0 a.k.a. "listen on all devices" or 127.0.0.1 a.k.a. localhost, but the port is interesting to see).