### PR TITLE
fix panic in send command

### DIFF
--- a/cmd/cashu/feni.go
+++ b/cmd/cashu/feni.go
@@ -2,14 +2,15 @@ package main
 
 import (
 	"fmt"
-	"github.com/c-bata/go-prompt"
-	"github.com/cashubtc/cashu-feni/cmd/cashu/feni"
 	"os"
 	"regexp"
 	"strings"
+
+	"github.com/c-bata/go-prompt"
+	"github.com/cashubtc/cashu-feni/cmd/cashu/feni"
 )
 
-var sendRegex = regexp.MustCompile("send [0-9] ")
+var sendRegex = regexp.MustCompile("send [0-9]")
 var advancedPrompt = &feni.CobraPrompt{
 	RootCmd:                  feni.RootCmd,
 	PersistFlagValues:        true,

--- a/cmd/cashu/feni/send.go
+++ b/cmd/cashu/feni/send.go
@@ -119,14 +119,10 @@ func send(cmd *cobra.Command, args []string) {
 		p2sh = true
 	}
 
-	keyset, err := Wallet.getKeySet(args[1])
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-	Wallet.Client.Url = keyset.MintUrl
-
+	mint, _ := strconv.Atoi(args[1])
+	Wallet.Client.Url = filteredKeySets[mint].MintUrl
 	Wallet.loadDefaultMint()
+
 	amount, err := strconv.ParseUint(args[0], 10, 64)
 	if err != nil {
 		fmt.Println("invalid amount")


### PR DESCRIPTION
this is for [#52 ](https://github.com/cashubtc/cashu-feni/issues/52). It looks like the panic was because it was trying to access  `filteredKeySets` which was not initialized. 

also have a question on the arguments for the send command and the assumption I made. I wasn't quite sure what is expected in the `mint_id` arg since it is being converted to an int? I'm assuming the value expected is the keyset id (since that is shown in the balance) so the change will get the mint url for that keyset passed.

let me know if that is how it is intended to be used or if not, I can change it.